### PR TITLE
fix/reproducible-builds-Dockerfile

### DIFF
--- a/reproducible-builds/Dockerfile
+++ b/reproducible-builds/Dockerfile
@@ -4,17 +4,20 @@ RUN set -ex; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes -o APT::Install-Suggests=false --no-install-recommends \
         bzip2 make automake ninja-build g++-multilib libtool binutils-gold \
-        bsdmainutils pkg-config python3 patch bison curl unzip git openjdk-17-jdk; \
+        bsdmainutils pkg-config python3 patch bison curl unzip git openjdk-17-jdk sudo nano; \
     rm -rf /var/lib/apt/lists/*; \
-    useradd -ms /bin/bash appuser;
-     
-USER appuser
+    useradd -ms /bin/bash appuser; \
+    usermod -aG sudo appuser; \
+    echo "appuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+USER appuser
+WORKDIR /home/appuser
+RUN mkdir -p /home/appuser/app
 ENV ANDROID_SDK_ROOT=/home/appuser/app/sdk
 ENV ANDROID_SDK=/home/appuser/app/sdk
 ENV ANDROID_HOME=/home/appuser/app/sdk
-
-WORKDIR /home/appuser/app/nunchuk/
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+WORKDIR /home/appuser/app/nunchuk
 
 ENV ANDROID_SDK_URL https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
 ENV ANDROID_BUILD_TOOLS_VERSION 34.0.0
@@ -25,16 +28,21 @@ ENV ANDROID_NDK_HOME ${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}/
 ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
 
 RUN set -ex; \
-    mkdir "$ANDROID_HOME" && \
-    cd "$ANDROID_HOME" && \
+    mkdir -p "$ANDROID_HOME/cmdline-tools" && \
+    cd "$ANDROID_HOME/cmdline-tools" && \
     curl -o sdk.zip $ANDROID_SDK_URL && \
     unzip sdk.zip && \
+    mv cmdline-tools latest && \
     rm sdk.zip
 
-RUN yes | ${ANDROID_HOME}/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses
-RUN $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --update
+RUN chmod +x ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager
 
-RUN $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME \
+RUN ls -l ${ANDROID_HOME}/cmdline-tools/latest/bin/
+
+RUN yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses
+RUN ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_HOME --update
+
+RUN $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_HOME \
     "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
     "platforms;android-${ANDROID_VERSION}" \
     "cmake;$ANDROID_CMAKE_VERSION" \
@@ -45,3 +53,4 @@ ENV PATH ${ANDROID_NDK_HOME}:$PATH
 ENV PATH ${ANDROID_NDK_HOME}/prebuilt/linux-x86_64/bin/:$PATH
 
 ENV GRADLE_USER_HOME=/home/appuser/app/nunchuk/.gradle-home
+


### PR DESCRIPTION
The current Dockerfile in the reproducible-builds folder has permission issues which make following the instructions in the readme quite difficult. 

Hopefully, this addresses issue https://github.com/nunchuk-io/nunchuk-android/issues/69