### PR TITLE
Warn users about ColdCard Mk3 seed-entropy advisory on Add COLDCARD screen

### DIFF
--- a/nunchuk-core/src/main/res/values/strings.xml
+++ b/nunchuk-core/src/main/res/values/strings.xml
@@ -1099,6 +1099,6 @@
     <string name="nc_recover_key_via_seed">Recover key via seed</string>
     <string name="nc_export_message">Export message</string>
     <string name="nc_retry">Retry</string>
-    <string name="nc_coldcard_seed_entropy_warning">Security warning: ColdCard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q generated seeds with reduced entropy. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds.</string>
+    <string name="nc_coldcard_seed_entropy_warning">Security warning: ColdCard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware generated seeds with reduced entropy. If your seed was generated on-device with fewer than 50 independent dice rolls, update firmware, generate a new seed and move your funds.</string>
     <string name="nc_coldcard_seed_entropy_warning_link">Read Coinkite\'s advisory</string>
 </resources>

--- a/nunchuk-core/src/main/res/values/strings.xml
+++ b/nunchuk-core/src/main/res/values/strings.xml
@@ -1099,4 +1099,6 @@
     <string name="nc_recover_key_via_seed">Recover key via seed</string>
     <string name="nc_export_message">Export message</string>
     <string name="nc_retry">Retry</string>
+    <string name="nc_coldcard_seed_entropy_warning">Security warning: ColdCard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q generated seeds with reduced entropy. If your seed was generated on-device without extra dice rolls, update firmware, generate a new seed and move your funds.</string>
+    <string name="nc_coldcard_seed_entropy_warning_link">Read Coinkite\'s advisory</string>
 </resources>

--- a/nunchuk-signer/src/main/java/com/nunchuk/android/signer/mk4/inheritance/ColdCardIntroFragment.kt
+++ b/nunchuk-signer/src/main/java/com/nunchuk/android/signer/mk4/inheritance/ColdCardIntroFragment.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -29,7 +30,11 @@ import androidx.navigation.fragment.findNavController
 import com.nunchuk.android.compose.ActionItem
 import com.nunchuk.android.compose.NcImageAppBar
 import com.nunchuk.android.compose.NunchukTheme
+import com.nunchuk.android.compose.HighlightMessageType
+import com.nunchuk.android.compose.NcHintMessage
 import com.nunchuk.android.core.sheet.BottomSheetOptionListener
+import com.nunchuk.android.core.util.ClickAbleText
+import com.nunchuk.android.core.util.openExternalLink
 import com.nunchuk.android.model.MembershipStep
 import com.nunchuk.android.share.membership.MembershipFragment
 import com.nunchuk.android.signer.R
@@ -220,6 +225,19 @@ internal fun ColdCardIntroScreen(
                         style = NunchukTheme.typography.body
                     )
                 }
+
+                val context = LocalContext.current
+                NcHintMessage(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    type = HighlightMessageType.WARNING,
+                    messages = listOf(
+                        ClickAbleText(content = stringResource(R.string.nc_coldcard_seed_entropy_warning)),
+                        ClickAbleText(
+                            content = stringResource(R.string.nc_coldcard_seed_entropy_warning_link),
+                            onClick = { context.openExternalLink("https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/") }
+                        )
+                    )
+                )
 
                 ActionItem(
                     title = stringResource(R.string.nc_add_coldcard_via_nfc),


### PR DESCRIPTION
## Summary

Shows a security warning on the **Add COLDCARD** screen, linking Coinkite's advisory.

In July 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) a firmware build error that reduced generated-seed entropy on **ColdCard Mk3** (firmware 4.0.1-5.0.3) and pre-fix **Mk4/Q**. Nunchuk doesn't generate the ColdCard seed, so this isn't a Nunchuk flaw — but users who add a ColdCard via Nunchuk may hold funds on an affected seed.

## Change (2 files)

- `nunchuk-core/.../res/values/strings.xml` — two new strings (warning text + link label).
- `nunchuk-signer/.../mk4/inheritance/ColdCardIntroFragment.kt` — one `NcHintMessage(type = HighlightMessageType.WARNING)` block in `ColdCardIntroScreen`, placed after the intro description and before the add-method list. The advisory link uses the existing `ClickAbleText` + `Context.openExternalLink(...)` pattern already used in this flow (e.g. `Mk4InfoContent.kt`, `ColdcardRecoverFragment.kt`).

Reuses existing components only (no new UI); i18n via string resources.

## Note

I wasn't able to build the Android app locally to screenshot, so a maintainer build/verify would be appreciated. The change mirrors an existing `NcHintMessage` usage in the same module.

Refs nunchuk-io/nunchuk-mobile-issues#31.
