### PR TITLE
[USDT] Make Liquid backend configurable

### DIFF
--- a/nunchuk-core/src/main/java/com/nunchuk/android/core/constants/Constants.kt
+++ b/nunchuk-core/src/main/java/com/nunchuk/android/core/constants/Constants.kt
@@ -42,8 +42,8 @@ object Constants {
 }
 
 /**
- * The Liquid (USDT) Electrum server is derived from the active [Chain] rather than being
- * user-editable. Liquid/USDT is not supported on signet, so no server is configured there.
+ * Returns the default Liquid (USDT) Electrum server for [chain]. Liquid/USDT is not supported
+ * on signet, so no server is configured there.
  */
 fun defaultLiquidServers(chain: Chain): List<String> = when (chain) {
     Chain.TESTNET -> listOf(Constants.LIQUID_TEST_NET_HOST)

--- a/nunchuk-core/src/main/java/com/nunchuk/android/core/domain/GetAppSettingUseCase.kt
+++ b/nunchuk-core/src/main/java/com/nunchuk/android/core/domain/GetAppSettingUseCase.kt
@@ -59,10 +59,12 @@ class GetAppSettingUseCase @Inject constructor(
             )
             return updateAppSettingUseCase(migrated).getOrThrow()
         }
-        val expectedLiquidServers = defaultLiquidServers(loaded.chain)
-        if (loaded.liquidServers != expectedLiquidServers) {
-            val corrected = loaded.copy(liquidServers = expectedLiquidServers)
-            return updateAppSettingUseCase(corrected).getOrThrow()
+        if (loaded.liquidServers.isEmpty()) {
+            val liquidServers = defaultLiquidServers(loaded.chain)
+            if (liquidServers.isNotEmpty()) {
+                val migrated = loaded.copy(liquidServers = liquidServers)
+                return updateAppSettingUseCase(migrated).getOrThrow()
+            }
         }
         return loaded
     }

--- a/nunchuk-core/src/main/java/com/nunchuk/android/core/persistence/NCSharePreferences.kt
+++ b/nunchuk-core/src/main/java/com/nunchuk/android/core/persistence/NCSharePreferences.kt
@@ -61,6 +61,14 @@ class NCSharePreferences @Inject constructor(context: Context) {
         get() = prefs.getString(SP_KEY_CUSTOM_SIGNET_SERVER, "").orEmpty()
         set(value) = prefs.edit().putString(SP_KEY_CUSTOM_SIGNET_SERVER, value).apply()
 
+    var customLiquidMainnetServer: String
+        get() = prefs.getString(SP_KEY_CUSTOM_LIQUID_MAINNET_SERVER, "").orEmpty()
+        set(value) = prefs.edit().putString(SP_KEY_CUSTOM_LIQUID_MAINNET_SERVER, value).apply()
+
+    var customLiquidTestnetServer: String
+        get() = prefs.getString(SP_KEY_CUSTOM_LIQUID_TESTNET_SERVER, "").orEmpty()
+        set(value) = prefs.edit().putString(SP_KEY_CUSTOM_LIQUID_TESTNET_SERVER, value).apply()
+
     companion object {
         private const val PACKAGE_PREFIX = "com.nunchuk.android"
         private const val APP_SHARE_PREFERENCE_NAME = "${PACKAGE_PREFIX}.pref"
@@ -73,5 +81,9 @@ class NCSharePreferences @Inject constructor(context: Context) {
         private const val SP_KEY_CUSTOM_MAINNET_SERVER = "${PACKAGE_PREFIX}.key.custom.server.mainnet"
         private const val SP_KEY_CUSTOM_TESTNET_SERVER = "${PACKAGE_PREFIX}.key.custom.server.testnet"
         private const val SP_KEY_CUSTOM_SIGNET_SERVER = "${PACKAGE_PREFIX}.key.custom.server.signet"
+        private const val SP_KEY_CUSTOM_LIQUID_MAINNET_SERVER =
+            "${PACKAGE_PREFIX}.key.custom.server.liquid.mainnet"
+        private const val SP_KEY_CUSTOM_LIQUID_TESTNET_SERVER =
+            "${PACKAGE_PREFIX}.key.custom.server.liquid.testnet"
     }
 }

--- a/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingEvent.kt
+++ b/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingEvent.kt
@@ -27,6 +27,8 @@ data class NetworkSettingState(
     val mainnetServer: String = "",
     val testnetServer: String = "",
     val signetServer: String = "",
+    val liquidMainnetServer: String = "",
+    val liquidTestnetServer: String = "",
 )
 
 sealed class NetworkSettingEvent {
@@ -35,6 +37,8 @@ sealed class NetworkSettingEvent {
         val mainnetServer: String,
         val testnetServer: String,
         val signetServer: String,
+        val liquidMainnetServer: String,
+        val liquidTestnetServer: String,
     ) : NetworkSettingEvent()
     object SignOutSuccessEvent : NetworkSettingEvent()
     data class LoadingEvent(val loading: Boolean) : NetworkSettingEvent()

--- a/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingFragment.kt
+++ b/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingFragment.kt
@@ -126,6 +126,14 @@ class NetworkSettingFragment : BaseFragment<ActivityNetworkSettingBinding>(){
             currentChain = Chain.SIGNET,
             selectedChain = state.appSetting.chain
         )
+        binding.tvMainNetLiquidHost.setupNetworkViewInfo(
+            currentChain = Chain.MAIN,
+            selectedChain = state.appSetting.chain
+        )
+        binding.tvTestNetLiquidHost.setupNetworkViewInfo(
+            currentChain = Chain.TESTNET,
+            selectedChain = state.appSetting.chain
+        )
 
         setupViewsWhenAppSettingChanged()
     }
@@ -171,6 +179,8 @@ class NetworkSettingFragment : BaseFragment<ActivityNetworkSettingBinding>(){
                 binding.tvMainNetHost.text = viewModel.customMainnetServerName ?: event.mainnetServer
                 binding.tvTestNetHost.setText(event.testnetServer)
                 binding.tvSigNetHost.setText(event.signetServer)
+                binding.tvMainNetLiquidHost.setText(event.liquidMainnetServer)
+                binding.tvTestNetLiquidHost.setText(event.liquidTestnetServer)
             }
 
             is NetworkSettingEvent.LoadingEvent -> showLoading()
@@ -204,6 +214,8 @@ class NetworkSettingFragment : BaseFragment<ActivityNetworkSettingBinding>(){
         binding.electrumServerSwitch.isEnabled = false
         binding.tvTestNetHost.inputType = InputType.TYPE_CLASS_TEXT
         binding.tvSigNetHost.inputType = InputType.TYPE_CLASS_TEXT
+        binding.tvMainNetLiquidHost.inputType = InputType.TYPE_CLASS_TEXT
+        binding.tvTestNetLiquidHost.inputType = InputType.TYPE_CLASS_TEXT
 
         binding.rbMainNet.setOnCheckedChangeListener { view, checked ->
             if (checked) {
@@ -236,6 +248,12 @@ class NetworkSettingFragment : BaseFragment<ActivityNetworkSettingBinding>(){
         }
         binding.tvSigNetHost.addTextChangedCallback {
             handleNetworkHostTextCallBack(it, Chain.SIGNET)
+        }
+        binding.tvMainNetLiquidHost.addTextChangedCallback {
+            viewModel.onLiquidHostChanged(Chain.MAIN, it)
+        }
+        binding.tvTestNetLiquidHost.addTextChangedCallback {
+            viewModel.onLiquidHostChanged(Chain.TESTNET, it)
         }
         val openSelectElectrumServer : () -> Unit = {
             selectServerLauncher.launch(
@@ -335,6 +353,14 @@ class NetworkSettingFragment : BaseFragment<ActivityNetworkSettingBinding>(){
         viewModel.onHostChanged(
             Chain.SIGNET,
             binding.tvSigNetHost.text.toString()
+        )
+        viewModel.onLiquidHostChanged(
+            Chain.MAIN,
+            binding.tvMainNetLiquidHost.text.toString()
+        )
+        viewModel.onLiquidHostChanged(
+            Chain.TESTNET,
+            binding.tvTestNetLiquidHost.text.toString()
         )
         viewModel.onChainChanged(chain)
     }

--- a/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingViewModel.kt
+++ b/nunchuk-settings/src/main/java/com/nunchuk/android/settings/network/NetworkSettingViewModel.kt
@@ -21,6 +21,8 @@ package com.nunchuk.android.settings.network
 
 import androidx.lifecycle.viewModelScope
 import com.nunchuk.android.arch.vm.NunchukViewModel
+import com.nunchuk.android.core.constants.Constants.LIQUID_MAIN_NET_HOST
+import com.nunchuk.android.core.constants.Constants.LIQUID_TEST_NET_HOST
 import com.nunchuk.android.core.constants.Constants.MAIN_NET_HOST
 import com.nunchuk.android.core.constants.Constants.SIG_NET_HOST
 import com.nunchuk.android.core.constants.Constants.TEST_NET_HOST
@@ -67,6 +69,8 @@ internal class NetworkSettingViewModel @Inject constructor(
     private var initMainnetServer: String = ""
     private var initTestnetServer: String = ""
     private var initSignetServer: String = ""
+    private var initLiquidMainnetServer: String = ""
+    private var initLiquidTestnetServer: String = ""
 
     init {
         viewModelScope.launch {
@@ -74,24 +78,58 @@ internal class NetworkSettingViewModel @Inject constructor(
                 val mainnet = ncSharePreferences.customMainnetServer.ifBlank { MAIN_NET_HOST }
                 val testnet = ncSharePreferences.customTestnetServer.ifBlank { TEST_NET_HOST }
                 val signet = ncSharePreferences.customSignetServer.ifBlank { SIG_NET_HOST }
+                val liquidMainnet = getLiquidServer(
+                    appSettings = appSettings,
+                    chain = Chain.MAIN,
+                    savedServer = ncSharePreferences.customLiquidMainnetServer,
+                    defaultServer = LIQUID_MAIN_NET_HOST,
+                )
+                val liquidTestnet = getLiquidServer(
+                    appSettings = appSettings,
+                    chain = Chain.TESTNET,
+                    savedServer = ncSharePreferences.customLiquidTestnetServer,
+                    defaultServer = LIQUID_TEST_NET_HOST,
+                )
                 initAppSettings = appSettings
                 initMainnetServer = mainnet
                 initTestnetServer = testnet
                 initSignetServer = signet
+                initLiquidMainnetServer = liquidMainnet
+                initLiquidTestnetServer = liquidTestnet
                 updateState {
                     copy(
                         appSetting = appSettings,
                         mainnetServer = mainnet,
                         testnetServer = testnet,
                         signetServer = signet,
+                        liquidMainnetServer = liquidMainnet,
+                        liquidTestnetServer = liquidTestnet,
                     )
                 }
                 loadCustomMainnetServer(mainnet)
                 setEvent(
-                    NetworkSettingEvent.ResetTextHostServerEvent(mainnet, testnet, signet)
+                    NetworkSettingEvent.ResetTextHostServerEvent(
+                        mainnet,
+                        testnet,
+                        signet,
+                        liquidMainnet,
+                        liquidTestnet,
+                    )
                 )
             }
         }
+    }
+
+    private fun getLiquidServer(
+        appSettings: AppSettings,
+        chain: Chain,
+        savedServer: String,
+        defaultServer: String,
+    ): String {
+        if (savedServer.isNotBlank()) return savedServer
+        return appSettings.liquidServers.firstOrNull()
+            ?.takeIf { appSettings.chain == chain && it.isNotBlank() }
+            ?: defaultServer
     }
 
     private suspend fun loadCustomMainnetServer(url: String?) {
@@ -126,6 +164,21 @@ internal class NetworkSettingViewModel @Inject constructor(
         updateState { withAppSetting }
     }
 
+    fun onLiquidHostChanged(chain: Chain, host: String) {
+        val current = state.value ?: return
+        val withHost = when (chain) {
+            Chain.MAIN -> current.copy(liquidMainnetServer = host)
+            Chain.TESTNET -> current.copy(liquidTestnetServer = host)
+            else -> current
+        }
+        val withAppSetting = if (current.appSetting.chain == chain) {
+            withHost.copy(appSetting = withHost.appSetting.copy(liquidServers = listOf(host)))
+        } else {
+            withHost
+        }
+        updateState { withAppSetting }
+    }
+
     fun onChainChanged(chain: Chain) {
         val current = state.value ?: return
         val newHost = when (chain) {
@@ -134,12 +187,18 @@ internal class NetworkSettingViewModel @Inject constructor(
             Chain.SIGNET -> current.signetServer
             else -> current.appSetting.electrumServers.firstOrNull().orEmpty()
         }
+        val newLiquidServers = when (chain) {
+            Chain.MAIN -> listOf(current.liquidMainnetServer)
+            Chain.TESTNET -> listOf(current.liquidTestnetServer)
+            Chain.SIGNET -> emptyList()
+            else -> defaultLiquidServers(chain)
+        }
         updateState {
             copy(
                 appSetting = appSetting.copy(
                     chain = chain,
                     electrumServers = listOf(newHost),
-                    liquidServers = defaultLiquidServers(chain),
+                    liquidServers = newLiquidServers,
                 )
             )
         }
@@ -151,6 +210,8 @@ internal class NetworkSettingViewModel @Inject constructor(
                 || current.mainnetServer != initMainnetServer
                 || current.testnetServer != initTestnetServer
                 || current.signetServer != initSignetServer
+                || current.liquidMainnetServer != initLiquidMainnetServer
+                || current.liquidTestnetServer != initLiquidTestnetServer
     }
 
     fun saveCurrentSettings() {
@@ -158,6 +219,8 @@ internal class NetworkSettingViewModel @Inject constructor(
         ncSharePreferences.customMainnetServer = current.mainnetServer
         ncSharePreferences.customTestnetServer = current.testnetServer
         ncSharePreferences.customSignetServer = current.signetServer
+        ncSharePreferences.customLiquidMainnetServer = current.liquidMainnetServer
+        ncSharePreferences.customLiquidTestnetServer = current.liquidTestnetServer
         updateAppSettings(current.appSetting)
     }
 
@@ -170,6 +233,8 @@ internal class NetworkSettingViewModel @Inject constructor(
                 initMainnetServer = state.value?.mainnetServer.orEmpty()
                 initTestnetServer = state.value?.testnetServer.orEmpty()
                 initSignetServer = state.value?.signetServer.orEmpty()
+                initLiquidMainnetServer = state.value?.liquidMainnetServer.orEmpty()
+                initLiquidTestnetServer = state.value?.liquidTestnetServer.orEmpty()
                 updateState {
                     copy(appSetting = saved)
                 }
@@ -183,18 +248,24 @@ internal class NetworkSettingViewModel @Inject constructor(
             ncSharePreferences.customMainnetServer = MAIN_NET_HOST
             ncSharePreferences.customTestnetServer = TEST_NET_HOST
             ncSharePreferences.customSignetServer = SIG_NET_HOST
+            ncSharePreferences.customLiquidMainnetServer = LIQUID_MAIN_NET_HOST
+            ncSharePreferences.customLiquidTestnetServer = LIQUID_TEST_NET_HOST
             val result = initAppSettingsUseCase(Unit)
             result.getOrNull()?.let {
                 initAppSettings = it
                 initMainnetServer = MAIN_NET_HOST
                 initTestnetServer = TEST_NET_HOST
                 initSignetServer = SIG_NET_HOST
+                initLiquidMainnetServer = LIQUID_MAIN_NET_HOST
+                initLiquidTestnetServer = LIQUID_TEST_NET_HOST
                 updateState {
                     copy(
                         appSetting = it,
                         mainnetServer = MAIN_NET_HOST,
                         testnetServer = TEST_NET_HOST,
                         signetServer = SIG_NET_HOST,
+                        liquidMainnetServer = LIQUID_MAIN_NET_HOST,
+                        liquidTestnetServer = LIQUID_TEST_NET_HOST,
                     )
                 }
                 setEvent(
@@ -202,6 +273,8 @@ internal class NetworkSettingViewModel @Inject constructor(
                         MAIN_NET_HOST,
                         TEST_NET_HOST,
                         SIG_NET_HOST,
+                        LIQUID_MAIN_NET_HOST,
+                        LIQUID_TEST_NET_HOST,
                     )
                 )
                 setEvent(NetworkSettingEvent.UpdateSettingSuccessEvent(it))

--- a/nunchuk-settings/src/main/res/layout/activity_network_setting.xml
+++ b/nunchuk-settings/src/main/res/layout/activity_network_setting.xml
@@ -74,6 +74,33 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
+                <com.nunchuk.android.widget.NCFontEditText
+                    android:id="@+id/tvMainNetLiquidHost"
+                    style="@style/NCText.Body"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="@dimen/nc_padding_16"
+                    android:background="@drawable/nc_edit_text_bg"
+                    android:gravity="start|center_vertical"
+                    android:padding="@dimen/nc_padding_12"
+                    android:textSize="@dimen/nc_text_size_16"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/rbMainNet"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tvMainNetLiquidServerTitle"
+                    tools:text="liquid.mainnet:50002" />
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/tvMainNetLiquidServerTitle"
+                    style="@style/NCText.EditText.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/nc_text_size_16"
+                    android:layout_marginTop="@dimen/nc_padding_16"
+                    android:text="@string/nc_text_liquid_server"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tvMainNetHost" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -118,6 +145,33 @@
                     android:text="@string/nc_text_testnet_server"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
+                <com.nunchuk.android.widget.NCFontEditText
+                    android:id="@+id/tvTestNetLiquidHost"
+                    style="@style/NCText.Body"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="@dimen/nc_padding_16"
+                    android:background="@drawable/nc_edit_text_bg"
+                    android:gravity="start|center_vertical"
+                    android:padding="@dimen/nc_padding_12"
+                    android:textSize="@dimen/nc_text_size_16"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/rbTestNet"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tvTestNetLiquidServerTitle"
+                    tools:text="liquid.testnet:50002" />
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/tvTestNetLiquidServerTitle"
+                    style="@style/NCText.EditText.Title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/nc_text_size_16"
+                    android:layout_marginTop="@dimen/nc_padding_16"
+                    android:text="@string/nc_text_liquid_server"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tvTestNetHost" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/nunchuk-settings/src/main/res/values/strings.xml
+++ b/nunchuk-settings/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="nc_text_sign_out_all_devices">Sign out all devices</string>
     <string name="nc_text_device_info">(This device)</string>
     <string name="nc_text_signet_server">Signet server</string>
+    <string name="nc_text_liquid_server">Liquid server</string>
     <string name="nc_txt_explorer_address">Explorer Address</string>
     <string name="nc_settings_developer_mode">Developer settings</string>
     <string name="nc_invite_friends">Invite friends</string>


### PR DESCRIPTION
## Summary

- keep the existing Liquid Electrum endpoints as defaults
- let users configure separate Liquid servers for mainnet and testnet
- persist custom Liquid servers across app restarts and network switches
- keep Liquid disabled on signet and restore defaults with the existing reset action

## Testing

- JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/monica/Library/Android/sdk ./gradlew --no-configuration-cache :nunchuk-settings:compileReleaseKotlin :nunchuk-core:compileReleaseKotlin
- XML validation and git diff checks

Closes https://github.com/nunchuk-io/nunchuk-android/issues/112